### PR TITLE
Fix: Event loop is closed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp==3.8.3
 aiosignal==1.2.0
 # aleph-client==0.5.0
-git+https://github.com/aleph-im/aleph-client@132fbdccec6bdabe5f8e2b3c1c24ce5968dc83a3
+git+https://github.com/aleph-im/aleph-client@1d177c489d017f54b5d6dc081fcb0c707138fcbb
 async-timeout==4.0.2
 attrs==21.4.0
 beautifulsoup4==4.11.1


### PR DESCRIPTION
Problem: the scoring system sometimes hangs when posting to Aleph. We suspect that the issue is caused by the reuse of the default aiohttp session of `aleph-client`. The scheduling system creates new asyncio event loops but the client session remains configured with the first one.

Solution: create a new aiohttp session object whenever pushing scores to Aleph instead of reusing the default one.