### PR TITLE
Fix: annotate versions correctly on release day

### DIFF
--- a/aleph_scoring/scoring/sql/query_ccn_measurements.sql
+++ b/aleph_scoring/scoring/sql/query_ccn_measurements.sql
@@ -79,7 +79,7 @@ SELECT node ->> 'node_id'                                                  as no
             case
                 when (
                     annotate_version('pyaleph', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'latest'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'latest'
                     ) then 1 end)
             as node_version_latest,
 
@@ -87,7 +87,7 @@ SELECT node ->> 'node_id'                                                  as no
             case
                 when (
                     annotate_version('pyaleph', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'prerelease'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'prerelease'
                     ) then 1 end)
             as node_version_prerelease,
 
@@ -95,7 +95,7 @@ SELECT node ->> 'node_id'                                                  as no
             case
                 when (
                     annotate_version('pyaleph', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'outdated'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'outdated'
                     ) then 1 end)
             as node_version_outdated,
 
@@ -103,7 +103,7 @@ SELECT node ->> 'node_id'                                                  as no
             case
                 when (
                     annotate_version('pyaleph', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'obsolete'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'obsolete'
                     ) then 1 end)
             as node_version_obsolete,
 
@@ -111,7 +111,7 @@ SELECT node ->> 'node_id'                                                  as no
             case
                 when (
                     annotate_version('pyaleph', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'other'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'other'
                     ) then 1 end)
             as node_version_other,
 

--- a/aleph_scoring/scoring/sql/query_crn_measurements.template.sql
+++ b/aleph_scoring/scoring/sql/query_crn_measurements.template.sql
@@ -50,7 +50,7 @@ SELECT node ->> 'node_id'                                                       
             case
                 when (
                     annotate_version('aleph-vm', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'latest'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'latest'
                     ) then 1 end)
             as node_version_latest,
 
@@ -58,7 +58,7 @@ SELECT node ->> 'node_id'                                                       
             case
                 when (
                     annotate_version('aleph-vm', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'prerelease'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'prerelease'
                     ) then 1 end)
             as node_version_prerelease,
 
@@ -66,7 +66,7 @@ SELECT node ->> 'node_id'                                                       
             case
                 when (
                     annotate_version('aleph-vm', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'outdated'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'outdated'
                     ) then 1 end)
             as node_version_outdated,
 
@@ -74,7 +74,7 @@ SELECT node ->> 'node_id'                                                       
             case
                 when (
                     annotate_version('aleph-vm', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'obsolete'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'obsolete'
                     ) then 1 end)
             as node_version_obsolete,
 
@@ -82,7 +82,7 @@ SELECT node ->> 'node_id'                                                       
             case
                 when (
                     annotate_version('aleph-vm', node ->> 'version',
-                                     to_timestamp((node ->> 'measured_at')::float)::date) = 'other'
+                                     to_timestamp((node->>'measured_at')::float)::timestamptz) = 'other'
                     ) then 1 end)
             as node_version_other,
 

--- a/aleph_scoring/scoring/sql/software_versions_function.sql
+++ b/aleph_scoring/scoring/sql/software_versions_function.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION annotate_version(software_name varchar, version_name varchar, version_date timestamp)
+CREATE OR REPLACE FUNCTION annotate_version(software_name varchar, version_name varchar, version_date timestamp with time zone)
     RETURNS VARCHAR
     language plpgsql
 as


### PR DESCRIPTION
Problem: nodes that move to a new release on the same day as its release get a poor version score because the annotation assumes that the node was updated before the release date.

Solution: cast the measurement time to timestamptz instead of date.