### PR TITLE
Fix: catch all aiohttp errors and add retry logic for CRN executions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,13 +15,13 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: "3.12"
-    - name: Install dependencies
+    - name: Install hatch
       run: |
         python -m pip install --upgrade pip
-        pip install mypy==1.11.2 black
+        pip install hatch
     - name: Lint with black
       run: |
-        black --check .
+        hatch run linting:style
     - name: Typing check
       run: |
-        mypy --config-file=pyproject.toml aleph_scoring/
+        hatch run typing:typing

--- a/aleph_scoring/executions/__init__.py
+++ b/aleph_scoring/executions/__init__.py
@@ -91,18 +91,41 @@ def get_compute_resource_node_urls(
 async def fetch_crn_executions(
     session: aiohttp.ClientSession, node_url: str
 ) -> Optional[dict[str, Any]]:
-    try:
-        async with asyncio.timeout(settings.HTTP_REQUEST_TIMEOUT):
-            async with session.get(node_url) as resp:
-                r = await resp.json()
-                return r
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            async with asyncio.timeout(settings.HTTP_REQUEST_TIMEOUT):
+                async with session.get(node_url) as resp:
+                    r = await resp.json()
+                    return r
 
-    except (aiohttp.ClientResponseError, aiohttp.ClientConnectorError) as e:
-        logger.debug(f"Error when fetching executions from {node_url} {e}")
-        return None
-    except asyncio.TimeoutError:
-        logger.debug(f"Timeout error when fetching executions from  {node_url}")
-        return None
+        except aiohttp.ClientError as e:
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                logger.debug(
+                    f"Error when fetching executions from {node_url} ({e}), "
+                    f"retrying in {wait}s (attempt {attempt + 1}/{max_retries})"
+                )
+                await asyncio.sleep(wait)
+            else:
+                logger.warning(
+                    f"Failed to fetch executions from {node_url} after {max_retries} attempts: {e}"
+                )
+                return None
+        except asyncio.TimeoutError:
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                logger.debug(
+                    f"Timeout when fetching executions from {node_url}, "
+                    f"retrying in {wait}s (attempt {attempt + 1}/{max_retries})"
+                )
+                await asyncio.sleep(wait)
+            else:
+                logger.warning(
+                    f"Timeout fetching executions from {node_url} after {max_retries} attempts"
+                )
+                return None
+    return None
 
 
 async def get_crn_executions(
@@ -174,7 +197,8 @@ async def collect_node_executions(
         total=60.0, connect=10.0, sock_connect=10.0, sock_read=60.0
     )
     return await asyncio.gather(
-        *[executions_function(timeout, node_info) for node_info in node_infos]
+        *[executions_function(timeout, node_info) for node_info in node_infos],
+        return_exceptions=True,
     )
 
 

--- a/aleph_scoring/metrics/asn.py
+++ b/aleph_scoring/metrics/asn.py
@@ -138,7 +138,7 @@ def _parse_asname_line(line: str) -> Tuple[str, str]:
     match = EXTRACT_ASNAME_C.match(line)
     if not match:
         raise ValueError(f"Could not parse line: {line}, no match found.")
-    return match.groups()  # type:ignore
+    return match.groups()  # type: ignore
 
 
 # Imported from pyasn_util_asnames.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ all = [
     "typing"
 ]
 
+[tool.black]
+target-version = ["py312"]
+
 [tool.mypy]
 python_version = "3.12"
 check_untyped_defs = true


### PR DESCRIPTION
A single node returning ServerDisconnectedError (or any unhandled aiohttp error) was propagating through asyncio.gather and crashing the entire executions round. Fix catches all aiohttp.ClientError subclasses, adds a 3-attempt retry with exponential backoff, and adds return_exceptions=True to the gather so any remaining unhandled error skips the node instead of blocking the payment system.