### PR TITLE
Add diagnostic issue codes to CRN metrics and scores

### DIFF
--- a/aleph_scoring/issue_codes.py
+++ b/aleph_scoring/issue_codes.py
@@ -1,0 +1,50 @@
+"""Diagnostic issue codes published for CRN operators.
+
+Only the numeric values appear in the published JSON (to keep the payload
+small). The names and descriptions here are the single source of truth and
+should be mirrored in the operator documentation.
+
+STABILITY CONTRACT: values are permanent. Never reuse or renumber a code once
+it has been published; only add new ones. Ranges:
+  1xxx  scoring reasons   -- why the aggregated score is low or zero
+  2xxx  measurement codes -- why an individual probe failed this cycle
+"""
+
+from enum import IntEnum
+from typing import Dict
+
+
+class IssueCode(IntEnum):
+    # 1xxx -- scoring reasons (aggregated over the scoring/stability window)
+    NO_IPV4 = 1001
+    NO_IPV6 = 1002
+    IPV4_UNSTABLE = 1003
+    IPV6_UNSTABLE = 1004
+
+    # 2xxx -- per-measurement failures (this measurement cycle)
+    DNS_IPV4_FAIL = 2001
+    DNS_IPV6_FAIL = 2002
+    IPV4_CHECK_FAILED = 2003
+    IPV6_CHECK_FAILED = 2004
+    VERSION_UNAVAILABLE = 2005
+    DIAG_VM_UNREACHABLE = 2006
+    FULL_CHECK_FAILED = 2007
+    UNKNOWN_MEASUREMENT_ERROR = 2999
+
+
+ISSUE_DESCRIPTIONS: Dict[IssueCode, str] = {
+    IssueCode.NO_IPV4: "No IPv4 address observed for the node in the stability window.",
+    IssueCode.NO_IPV6: "No IPv6 address observed for the node in the stability window.",
+    IssueCode.IPV4_UNSTABLE: "The node's IPv4 address changed too many times.",
+    IssueCode.IPV6_UNSTABLE: "The node's IPv6 /64 prefix changed too many times.",
+    IssueCode.DNS_IPV4_FAIL: "The node hostname did not resolve to an IPv4 address.",
+    IssueCode.DNS_IPV6_FAIL: "The node hostname did not resolve to an IPv6 address.",
+    IssueCode.IPV4_CHECK_FAILED: "The IPv4 reachability check (about/login) failed.",
+    IssueCode.IPV6_CHECK_FAILED: "The IPv6 reachability check (about/login) failed.",
+    IssueCode.VERSION_UNAVAILABLE: "The aleph-vm version could not be read from the node.",
+    IssueCode.DIAG_VM_UNREACHABLE: "The diagnostic VM did not respond.",
+    IssueCode.FULL_CHECK_FAILED: "The status/check/fastapi probe failed.",
+    IssueCode.UNKNOWN_MEASUREMENT_ERROR: (
+        "An unexpected error occurred while measuring the node; see node logs."
+    ),
+}

--- a/aleph_scoring/metrics/__init__.py
+++ b/aleph_scoring/metrics/__init__.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel, validator
 from urllib3.util import Url, parse_url
 
 from aleph_scoring.config import settings
+from aleph_scoring.issue_codes import IssueCode
 from aleph_scoring.metrics.asn import get_asn_database
 from aleph_scoring.metrics.models import (
     AlephNodeMetrics,
@@ -416,7 +417,75 @@ async def fetch_supported_features(
         return None
 
 
+def crn_measurement_codes(
+    *,
+    ipv4: Optional[str],
+    ipv6: Optional[str],
+    version: Optional[str],
+    base_latency: Optional[float],
+    base_latency_ipv4: Optional[float],
+    diagnostic_vm_latency: Optional[float],
+    full_check_latency: Optional[float],
+) -> List[IssueCode]:
+    """Derive per-measurement diagnostic codes from this cycle's results.
+
+    Codes are inferred from which probes returned no value, so no exception
+    plumbing is needed. Granularity is per-probe (a failure, not its cause).
+    """
+    codes: List[IssueCode] = []
+    if ipv4 is None:
+        codes.append(IssueCode.DNS_IPV4_FAIL)
+    if ipv6 is None:
+        codes.append(IssueCode.DNS_IPV6_FAIL)
+    if base_latency_ipv4 is None:
+        codes.append(IssueCode.IPV4_CHECK_FAILED)
+    if base_latency is None:
+        codes.append(IssueCode.IPV6_CHECK_FAILED)
+    if version is None:
+        codes.append(IssueCode.VERSION_UNAVAILABLE)
+    if diagnostic_vm_latency is None:
+        codes.append(IssueCode.DIAG_VM_UNREACHABLE)
+    if full_check_latency is None:
+        codes.append(IssueCode.FULL_CHECK_FAILED)
+    return codes
+
+
 async def get_crn_metrics(
+    asn_db: pyasn.pyasn,
+    node_info: NodeInfo,
+    *,
+    sessions: CrnSessions,
+) -> CrnMetrics:
+    """Fetch or measure the metrics of a Compute Resource Node.
+
+    Any unexpected error is caught and reported as a minimal record carrying
+    UNKNOWN_MEASUREMENT_ERROR, so a single node's failure neither aborts the run
+    nor silently drops the node from the published metrics.
+    """
+    try:
+        return await _measure_crn_metrics(asn_db, node_info, sessions=sessions)
+    except Exception:
+        logger.exception(
+            "Unexpected error measuring CRN %s (%s)",
+            node_info.hash,
+            node_info.url.url,
+        )
+        return CrnMetrics(
+            measured_at=datetime.now(tz=timezone.utc).timestamp(),
+            node_id=node_info.hash,
+            url=node_info.url.url,
+            asn=None,
+            as_name=None,
+            version=None,
+            base_latency=None,
+            base_latency_ipv4=None,
+            diagnostic_vm_latency=None,
+            full_check_latency=None,
+            codes=[int(IssueCode.UNKNOWN_MEASUREMENT_ERROR)],
+        )
+
+
+async def _measure_crn_metrics(
     asn_db: pyasn.pyasn,
     node_info: NodeInfo,
     *,
@@ -478,6 +547,16 @@ async def get_crn_metrics(
 
     measured_at = datetime.now(tz=timezone.utc)
 
+    codes = crn_measurement_codes(
+        ipv4=ipv4,
+        ipv6=ipv6,
+        version=version,
+        base_latency=base_latency,
+        base_latency_ipv4=base_latency_ipv4,
+        diagnostic_vm_latency=diagnostic_vm_latency,
+        full_check_latency=full_check_latency,
+    )
+
     return CrnMetrics(
         measured_at=measured_at.timestamp(),
         node_id=node_info.hash,
@@ -493,6 +572,7 @@ async def get_crn_metrics(
         features=features_supported or [],
         ipv4=ipv4,
         ipv6=ipv6,
+        codes=[int(c) for c in codes],
     )
 
 

--- a/aleph_scoring/metrics/models.py
+++ b/aleph_scoring/metrics/models.py
@@ -37,6 +37,10 @@ class CrnMetrics(AlephNodeMetrics):
     ipv6: Optional[str] = Field(
         default=None, description="Resolved IPv6 address, used to detect IP changes"
     )
+    codes: List[int] = Field(
+        default_factory=list,
+        description="Numeric diagnostic codes for failed probes (see IssueCode)",
+    )
 
 
 class NodeMetrics(BaseModel):

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -7,6 +7,7 @@ from typing import AsyncIterable, Dict, List, Optional
 import asyncpg
 
 from aleph_scoring.config import settings
+from aleph_scoring.issue_codes import IssueCode
 from aleph_scoring.scoring.models import (
     CcnMeasurements,
     CcnScore,
@@ -118,6 +119,24 @@ def _ip_stability_fields(stability: Optional[Dict]) -> Dict:
         "ipv6_changes": ipv6_changes,
         "ip_penalized": ip_penalized,
     }
+
+
+def crn_score_codes(measurements: CrnMeasurements) -> List[IssueCode]:
+    """Derive scoring-reason codes from a CRN's aggregated measurements.
+
+    Emitted whenever the condition holds, independently of
+    IP_STABILITY_ENFORCED, so operators get early warning before scores drop.
+    """
+    codes: List[IssueCode] = []
+    if not measurements.has_ipv4:
+        codes.append(IssueCode.NO_IPV4)
+    if not measurements.has_ipv6:
+        codes.append(IssueCode.NO_IPV6)
+    if measurements.ipv4_changes >= settings.IP_MAX_CHANGES:
+        codes.append(IssueCode.IPV4_UNSTABLE)
+    if measurements.ipv6_changes >= settings.IP_MAX_CHANGES:
+        codes.append(IssueCode.IPV6_UNSTABLE)
+    return codes
 
 
 async def query_crn_measurements(
@@ -270,6 +289,7 @@ async def compute_crn_scores(
                 total_score=total_score,
                 decentralization=decentralization_score,
                 measurements=measurements,
+                codes=[int(c) for c in crn_score_codes(measurements)],
             )
         )
 

--- a/aleph_scoring/scoring/models.py
+++ b/aleph_scoring/scoring/models.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import BaseModel, ConstrainedFloat
+from pydantic import BaseModel, ConstrainedFloat, Field
 
 from aleph_scoring.utils import Period
 
@@ -44,6 +44,10 @@ class CcnScore(AlephNodeScore):
 
 class CrnScore(AlephNodeScore):
     measurements: CrnMeasurements
+    codes: List[int] = Field(
+        default_factory=list,
+        description="Numeric diagnostic codes explaining the score (see IssueCode)",
+    )
 
 
 class NodeScores(BaseModel):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,74 @@
+import pytest
+from urllib3.util import parse_url
+
+from aleph_scoring import metrics
+from aleph_scoring.issue_codes import IssueCode
+from aleph_scoring.metrics import NodeInfo, crn_measurement_codes, get_crn_metrics
+
+
+def _kwargs(**overrides):
+    base = dict(
+        ipv4="1.2.3.4",
+        ipv6="2a01::1",
+        version="1.0.0",
+        base_latency=0.1,
+        base_latency_ipv4=0.1,
+        diagnostic_vm_latency=0.1,
+        full_check_latency=0.1,
+    )
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        ({}, []),  # everything succeeded -> no codes
+        ({"ipv4": None}, [IssueCode.DNS_IPV4_FAIL]),
+        ({"ipv6": None}, [IssueCode.DNS_IPV6_FAIL]),
+        ({"base_latency_ipv4": None}, [IssueCode.IPV4_CHECK_FAILED]),
+        ({"base_latency": None}, [IssueCode.IPV6_CHECK_FAILED]),
+        ({"version": None}, [IssueCode.VERSION_UNAVAILABLE]),
+        ({"diagnostic_vm_latency": None}, [IssueCode.DIAG_VM_UNREACHABLE]),
+        ({"full_check_latency": None}, [IssueCode.FULL_CHECK_FAILED]),
+    ],
+)
+def test_crn_measurement_codes_single(overrides, expected):
+    assert crn_measurement_codes(**_kwargs(**overrides)) == expected
+
+
+def test_crn_measurement_codes_all_failed():
+    codes = crn_measurement_codes(
+        ipv4=None,
+        ipv6=None,
+        version=None,
+        base_latency=None,
+        base_latency_ipv4=None,
+        diagnostic_vm_latency=None,
+        full_check_latency=None,
+    )
+    assert codes == [
+        IssueCode.DNS_IPV4_FAIL,
+        IssueCode.DNS_IPV6_FAIL,
+        IssueCode.IPV4_CHECK_FAILED,
+        IssueCode.IPV6_CHECK_FAILED,
+        IssueCode.VERSION_UNAVAILABLE,
+        IssueCode.DIAG_VM_UNREACHABLE,
+        IssueCode.FULL_CHECK_FAILED,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_crn_metrics_reports_unexpected_error(monkeypatch):
+    async def boom(*args, **kwargs):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(metrics, "_measure_crn_metrics", boom)
+    node = NodeInfo(url=parse_url("https://crn.example/"), hash="a" * 64)
+
+    result = await get_crn_metrics(None, node, sessions=None)
+
+    assert result.node_id == "a" * 64
+    assert result.url == "https://crn.example/"
+    assert result.codes == [int(IssueCode.UNKNOWN_MEASUREMENT_ERROR)]
+    assert result.base_latency is None

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -3,7 +3,12 @@ import datetime as dt
 import pytest
 
 from aleph_scoring import scoring
-from aleph_scoring.scoring import compute_ccn_scores, compute_crn_scores
+from aleph_scoring.issue_codes import IssueCode
+from aleph_scoring.scoring import (
+    compute_ccn_scores,
+    compute_crn_scores,
+    crn_score_codes,
+)
 from aleph_scoring.scoring.models import CcnMeasurements, CrnMeasurements
 from aleph_scoring.utils import Period
 
@@ -147,6 +152,32 @@ async def test_compute_crn_scores(monkeypatch, period):
 )
 def test_ip_stability_penalty_rule(stability, expected):
     assert scoring._ip_stability_fields(stability)["ip_penalized"] is expected
+
+
+def _crn_measurements(**overrides) -> CrnMeasurements:
+    base = dict(
+        total_nodes=1, nodes_with_identical_asn=1, record_count=1, total_score=0.9
+    )
+    base.update(overrides)
+    return CrnMeasurements(**base)
+
+
+@pytest.mark.parametrize(
+    "overrides, expected",
+    [
+        ({}, []),  # clean node -> no codes
+        ({"has_ipv4": False}, [IssueCode.NO_IPV4]),
+        ({"has_ipv6": False}, [IssueCode.NO_IPV6]),
+        ({"ipv4_changes": 2}, [IssueCode.IPV4_UNSTABLE]),
+        ({"ipv6_changes": 3}, [IssueCode.IPV6_UNSTABLE]),
+        (
+            {"has_ipv6": False, "ipv4_changes": 5},
+            [IssueCode.NO_IPV6, IssueCode.IPV4_UNSTABLE],
+        ),
+    ],
+)
+def test_crn_score_codes(overrides, expected):
+    assert crn_score_codes(_crn_measurements(**overrides)) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
  Publish a compact list of numeric codes so operators can diagnose why
  a node fails a probe or scores low. Names live in an IssueCode enum
  (single source of truth) but only the integer values serialize.

  - Per-measurement codes (2xxx) on CrnMetrics, derived from probe results: DNS failures, IPv4/IPv6 reachability, version, diagnostic VM, full check.
  - Scoring-reason codes (1xxx) on CrnScore from the IP-stability fields, emitted regardless of IP_STABILITY_ENFORCED for early warning.
  - Catch unexpected errors in get_crn_metrics and report them as UNKNOWN_MEASUREMENT_ERROR instead of silently dropping the node.