### PR TITLE
Penalize CRNs that share an IP with an older node

### DIFF
--- a/aleph_scoring/config.py
+++ b/aleph_scoring/config.py
@@ -56,6 +56,10 @@ class Settings(BaseSettings):
     IP_MAX_CHANGES: int = 2
     IP_STABILITY_ENFORCED: bool = False
 
+    # When several CRNs share an IPv4 or an IPv6 /64, only the earliest-registered
+    # one is scored; the rest are treated as duplicates and forced to 0.
+    DUPLICATE_IP_ENFORCED: bool = True
+
     class Config:
         env_file = ".env"
         env_prefix = "ALEPH_SCORING_"

--- a/aleph_scoring/issue_codes.py
+++ b/aleph_scoring/issue_codes.py
@@ -20,6 +20,7 @@ class IssueCode(IntEnum):
     NO_IPV6 = 1002
     IPV4_UNSTABLE = 1003
     IPV6_UNSTABLE = 1004
+    DUPLICATE_IP = 1005
 
     # 2xxx -- per-measurement failures (this measurement cycle)
     DNS_IPV4_FAIL = 2001
@@ -37,6 +38,10 @@ ISSUE_DESCRIPTIONS: Dict[IssueCode, str] = {
     IssueCode.NO_IPV6: "No IPv6 address observed for the node in the stability window.",
     IssueCode.IPV4_UNSTABLE: "The node's IPv4 address changed too many times.",
     IssueCode.IPV6_UNSTABLE: "The node's IPv6 /64 prefix changed too many times.",
+    IssueCode.DUPLICATE_IP: (
+        "Shares an IPv4 or IPv6 /64 with an older CRN; only the "
+        "earliest-registered node on a given address is scored."
+    ),
     IssueCode.DNS_IPV4_FAIL: "The node hostname did not resolve to an IPv4 address.",
     IssueCode.DNS_IPV6_FAIL: "The node hostname did not resolve to an IPv6 address.",
     IssueCode.IPV4_CHECK_FAILED: "The IPv4 reachability check (about/login) failed.",

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -91,20 +91,27 @@ async def query_crn_ip_stability(
             "has_ipv6": row["has_ipv6"],
             "ipv4_changes": row["ipv4_changes"],
             "ipv6_changes": row["ipv6_changes"],
-            "ipv4": row["ipv4"],
-            "ipv6_prefix": row["ipv6_prefix"],
+            "ipv4": row["current_ipv4"],
+            "ipv6_prefix": row["current_ipv6_prefix"],
         }
         for row in values
     }
 
 
 def crn_registration_times(node_data: Dict[str, Any]) -> Dict[str, float]:
-    """Map each CRN node_id (hash) to its registration timestamp."""
-    return {
-        node["hash"]: node["time"]
-        for node in node_data.get("resource_nodes", [])
-        if isinstance(node.get("time"), (int, float))
-    }
+    """Map each CRN node_id (hash) to its registration timestamp.
+
+    Accepts numeric or numeric-string ``time`` values. Nodes whose time cannot
+    be parsed are omitted, which makes them sort last when choosing the keeper
+    of a duplicate group (so they never displace a node with a known time).
+    """
+    times: Dict[str, float] = {}
+    for node in node_data.get("resource_nodes", []):
+        try:
+            times[node["hash"]] = float(node["time"])
+        except (KeyError, TypeError, ValueError):
+            continue
+    return times
 
 
 def compute_duplicate_crns(

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -2,12 +2,13 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import AsyncIterable, Dict, List, Optional
+from typing import Any, AsyncIterable, Dict, List, Optional, Set
 
 import asyncpg
 
 from aleph_scoring.config import settings
 from aleph_scoring.issue_codes import IssueCode
+from aleph_scoring.metrics import get_aleph_nodes
 from aleph_scoring.scoring.models import (
     CcnMeasurements,
     CcnScore,
@@ -90,9 +91,49 @@ async def query_crn_ip_stability(
             "has_ipv6": row["has_ipv6"],
             "ipv4_changes": row["ipv4_changes"],
             "ipv6_changes": row["ipv6_changes"],
+            "ipv4": row["ipv4"],
+            "ipv6_prefix": row["ipv6_prefix"],
         }
         for row in values
     }
+
+
+def crn_registration_times(node_data: Dict[str, Any]) -> Dict[str, float]:
+    """Map each CRN node_id (hash) to its registration timestamp."""
+    return {
+        node["hash"]: node["time"]
+        for node in node_data.get("resource_nodes", [])
+        if isinstance(node.get("time"), (int, float))
+    }
+
+
+def compute_duplicate_crns(
+    ip_stability: Dict[str, Dict],
+    registration_times: Dict[str, float],
+) -> Set[str]:
+    """Return node_ids that share an IPv4 or IPv6 /64 with an older CRN.
+
+    For each address (IPv4 and IPv6 /64 grouped independently), the
+    earliest-registered node keeps its score and the rest are flagged. A node is
+    penalized if it is not the keeper in its IPv4 cohort or its /64 cohort.
+    Nodes with an unknown registration time sort last, so they never win a tie.
+    """
+    penalized: Set[str] = set()
+    for key in ("ipv4", "ipv6_prefix"):
+        groups: Dict[str, List[str]] = {}
+        for node_id, info in ip_stability.items():
+            address = info.get(key)
+            if address:
+                groups.setdefault(address, []).append(node_id)
+        for members in groups.values():
+            if len(members) < 2:
+                continue
+            keeper = min(
+                members,
+                key=lambda n: registration_times.get(n, float("inf")),
+            )
+            penalized.update(n for n in members if n != keeper)
+    return penalized
 
 
 def _ip_stability_fields(stability: Optional[Dict]) -> Dict:
@@ -136,6 +177,8 @@ def crn_score_codes(measurements: CrnMeasurements) -> List[IssueCode]:
         codes.append(IssueCode.IPV4_UNSTABLE)
     if measurements.ipv6_changes >= settings.IP_MAX_CHANGES:
         codes.append(IssueCode.IPV6_UNSTABLE)
+    if measurements.duplicate_ip:
+        codes.append(IssueCode.DUPLICATE_IP)
     return codes
 
 
@@ -143,6 +186,7 @@ async def query_crn_measurements(
     conn: asyncpg.connection,
     asn_info: Dict,
     ip_stability: Dict,
+    duplicate_ids: Set[str],
     period: Period,
 ) -> AsyncIterable[tuple[str, CrnMeasurements]]:
     sql = read_sql_file("dev/neo/query_crn_scores.template.sql")
@@ -173,6 +217,7 @@ async def query_crn_measurements(
         row = dict(record)
         row.update(node_asn_info)
         row.update(_ip_stability_fields(ip_stability.get(node_id)))
+        row["duplicate_ip"] = node_id in duplicate_ids
         yield node_id, CrnMeasurements.parse_obj(row)
 
 
@@ -184,11 +229,17 @@ async def compute_crn_scores(
     asn_info: Dict[str, Dict] = await query_crn_asn_info(conn, period=period)
     ip_stability: Dict[str, Dict] = await query_crn_ip_stability(conn, period=period)
 
+    node_data = await get_aleph_nodes()
+    duplicate_ids = compute_duplicate_crns(
+        ip_stability, crn_registration_times(node_data)
+    )
+
     result = []
     async for node_id, measurements in query_crn_measurements(
         conn,
         asn_info,
         ip_stability,
+        duplicate_ids,
         period,
     ):
         # # This contains custom logic on the scores
@@ -274,6 +325,10 @@ async def compute_crn_scores(
                 measurements.ipv4_changes,
                 measurements.ipv6_changes,
             )
+            total_score = Score(0)
+
+        if settings.DUPLICATE_IP_ENFORCED and measurements.duplicate_ip:
+            logger.info("Zeroing CRN %s as a duplicate-IP node", node_id)
             total_score = Score(0)
 
         decentralization_score = Score(

--- a/aleph_scoring/scoring/models.py
+++ b/aleph_scoring/scoring/models.py
@@ -26,6 +26,8 @@ class CrnMeasurements(BaseNodeMeasurements):
     ipv4_changes: int = 0
     ipv6_changes: int = 0  # counted at the /64 prefix, not the full address
     ip_penalized: bool = False
+    # True when this node shares an IPv4 or IPv6 /64 with an older CRN.
+    duplicate_ip: bool = False
 
 
 class CcnMeasurements(BaseNodeMeasurements):

--- a/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
+++ b/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
@@ -59,8 +59,8 @@ SELECT
     ) AS ipv6_changes,
     -- Most-recent non-null address, used to group duplicate CRNs.
     (array_agg(ipv4 ORDER BY hour DESC) FILTER (WHERE ipv4 IS NOT NULL))[1]
-        AS ipv4,
+        AS current_ipv4,
     (array_agg(ipv6_prefix ORDER BY hour DESC) FILTER (WHERE ipv6_prefix IS NOT NULL))[1]
-        AS ipv6_prefix
+        AS current_ipv6_prefix
 FROM ordered
 GROUP BY node_id;

--- a/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
+++ b/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
@@ -38,6 +38,7 @@ per_hour AS (
 ordered AS (
     SELECT
         node_id,
+        hour,
         ipv4,
         ipv6_prefix,
         LAG(ipv4) OVER (PARTITION BY node_id ORDER BY hour) AS prev_ipv4,
@@ -55,6 +56,11 @@ SELECT
         WHERE prev_ipv6_prefix IS NOT NULL
           AND ipv6_prefix IS NOT NULL
           AND ipv6_prefix <> prev_ipv6_prefix
-    ) AS ipv6_changes
+    ) AS ipv6_changes,
+    -- Most-recent non-null address, used to group duplicate CRNs.
+    (array_agg(ipv4 ORDER BY hour DESC) FILTER (WHERE ipv4 IS NOT NULL))[1]
+        AS ipv4,
+    (array_agg(ipv6_prefix ORDER BY hour DESC) FILTER (WHERE ipv6_prefix IS NOT NULL))[1]
+        AS ipv6_prefix
 FROM ordered
 GROUP BY node_id;

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -7,6 +7,7 @@ from aleph_scoring.issue_codes import IssueCode
 from aleph_scoring.scoring import (
     compute_ccn_scores,
     compute_crn_scores,
+    compute_duplicate_crns,
     crn_score_codes,
 )
 from aleph_scoring.scoring.models import CcnMeasurements, CrnMeasurements
@@ -52,7 +53,11 @@ def _patch_db(
         async def fake_stability(_conn, period):
             return {}
 
+        async def fake_nodes():
+            return {"resource_nodes": []}
+
         monkeypatch.setattr(scoring, stability_name, fake_stability)
+        monkeypatch.setattr(scoring, "get_aleph_nodes", fake_nodes)
 
 
 @pytest.mark.asyncio
@@ -174,10 +179,60 @@ def _crn_measurements(**overrides) -> CrnMeasurements:
             {"has_ipv6": False, "ipv4_changes": 5},
             [IssueCode.NO_IPV6, IssueCode.IPV4_UNSTABLE],
         ),
+        ({"duplicate_ip": True}, [IssueCode.DUPLICATE_IP]),
     ],
 )
 def test_crn_score_codes(overrides, expected):
     assert crn_score_codes(_crn_measurements(**overrides)) == expected
+
+
+@pytest.mark.parametrize(
+    "ip_stability, times, expected",
+    [
+        # Unique addresses -> no duplicates
+        (
+            {"a": {"ipv4": "1.1.1.1"}, "b": {"ipv4": "2.2.2.2"}},
+            {"a": 1, "b": 2},
+            set(),
+        ),
+        # Same IPv4: later registration penalized, earliest kept
+        (
+            {"a": {"ipv4": "1.1.1.1"}, "b": {"ipv4": "1.1.1.1"}},
+            {"a": 1, "b": 2},
+            {"b"},
+        ),
+        # Same /64: earliest kept
+        (
+            {"a": {"ipv6_prefix": "2a01::/64"}, "b": {"ipv6_prefix": "2a01::/64"}},
+            {"a": 5, "b": 3},
+            {"a"},
+        ),
+        # Shares IPv4 with one and /64 with another -> only earliest survives
+        (
+            {
+                "a": {"ipv4": "1.1.1.1", "ipv6_prefix": "2a01::/64"},
+                "b": {"ipv4": "1.1.1.1"},
+                "c": {"ipv6_prefix": "2a01::/64"},
+            },
+            {"a": 1, "b": 2, "c": 3},
+            {"b", "c"},
+        ),
+        # Null addresses are not grouped
+        (
+            {"a": {"ipv4": None, "ipv6_prefix": None}, "b": {"ipv4": None}},
+            {"a": 1, "b": 2},
+            set(),
+        ),
+        # Unknown registration time sorts last (never keeper)
+        (
+            {"a": {"ipv4": "1.1.1.1"}, "b": {"ipv4": "1.1.1.1"}},
+            {"b": 2},  # "a" has no time
+            {"a"},
+        ),
+    ],
+)
+def test_compute_duplicate_crns(ip_stability, times, expected):
+    assert compute_duplicate_crns(ip_stability, times) == expected
 
 
 @pytest.mark.asyncio
@@ -208,3 +263,32 @@ async def test_compute_crn_scores_zeroes_penalized_when_enforced(monkeypatch, pe
     scores = await compute_crn_scores(period=period)
 
     assert scores[0].total_score == 0  # zeroed despite total_score=0.95
+
+
+@pytest.mark.asyncio
+async def test_compute_crn_scores_zeroes_duplicate_when_enforced(monkeypatch, period):
+    monkeypatch.setattr(scoring.settings, "DUPLICATE_IP_ENFORCED", True)
+    rows = [
+        (
+            "crn-dup",
+            CrnMeasurements(
+                total_nodes=2,
+                nodes_with_identical_asn=1,
+                record_count=5,
+                total_score=0.95,
+                duplicate_ip=True,
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    scores = await compute_crn_scores(period=period)
+
+    assert scores[0].total_score == 0
+    assert int(IssueCode.DUPLICATE_IP) in scores[0].codes

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -292,3 +292,35 @@ async def test_compute_crn_scores_zeroes_duplicate_when_enforced(monkeypatch, pe
 
     assert scores[0].total_score == 0
     assert int(IssueCode.DUPLICATE_IP) in scores[0].codes
+
+
+@pytest.mark.asyncio
+async def test_compute_crn_scores_keeps_duplicate_when_not_enforced(
+    monkeypatch, period
+):
+    monkeypatch.setattr(scoring.settings, "DUPLICATE_IP_ENFORCED", False)
+    rows = [
+        (
+            "crn-dup",
+            CrnMeasurements(
+                total_nodes=2,
+                nodes_with_identical_asn=1,
+                record_count=5,
+                total_score=0.95,
+                duplicate_ip=True,
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    scores = await compute_crn_scores(period=period)
+
+    # Score is NOT zeroed, but the code is still published for early warning.
+    assert scores[0].total_score == 0.95
+    assert int(IssueCode.DUPLICATE_IP) in scores[0].codes


### PR DESCRIPTION
  When multiple CRNs present the same IPv4 or IPv6 /64, only the
  earliest-registered node is scored; the rest are forced to 0. Targets
  Sybil clusters where many node entries run behind one machine and each
  draws rewards.

  - Extend query_crn_ip_stability.sql to also return each node's most-recent representative IPv4 and /64.
  - compute_duplicate_crns groups nodes by address (IPv4 and /64 independently) and flags every node that is not the earliest by registration time (node aggregate `time`).
  - Add duplicate_ip to CrnMeasurements and the DUPLICATE_IP (1005) issue code, published whenever the condition holds.
  - Gate the score zeroing on DUPLICATE_IP_ENFORCED (default true).