### PR TITLE
Zero decentralization for duplicate CRNs and harden node fetch

### DIFF
--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -251,7 +251,7 @@ async def compute_crn_scores(
     # Duplicates are excluded from the per-ASN "identical" count so a Sybil
     # cluster cannot make its ASN look crowded and drag down honest nodes'
     # decentralization. total_nodes is intentionally left untouched.
-    duplicate_asn_counts: "Counter[int]" = Counter()
+    duplicate_asn_counts: Counter[int] = Counter()
     if settings.DUPLICATE_IP_ENFORCED:
         duplicate_asn_counts = Counter(
             asn_info[nid]["asn"]

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterable, Dict, List, Optional, Set
@@ -236,10 +237,27 @@ async def compute_crn_scores(
     asn_info: Dict[str, Dict] = await query_crn_asn_info(conn, period=period)
     ip_stability: Dict[str, Dict] = await query_crn_ip_stability(conn, period=period)
 
-    node_data = await get_aleph_nodes()
+    try:
+        node_data = await get_aleph_nodes()
+    except Exception:
+        logger.exception(
+            "Could not fetch node data; skipping duplicate-IP detection this run"
+        )
+        node_data = {}
     duplicate_ids = compute_duplicate_crns(
         ip_stability, crn_registration_times(node_data)
     )
+
+    # Duplicates are excluded from the per-ASN "identical" count so a Sybil
+    # cluster cannot make its ASN look crowded and drag down honest nodes'
+    # decentralization. total_nodes is intentionally left untouched.
+    duplicate_asn_counts: "Counter[int]" = Counter()
+    if settings.DUPLICATE_IP_ENFORCED:
+        duplicate_asn_counts = Counter(
+            asn_info[nid]["asn"]
+            for nid in duplicate_ids
+            if nid in asn_info and asn_info[nid].get("asn") is not None
+        )
 
     result = []
     async for node_id, measurements in query_crn_measurements(
@@ -338,10 +356,16 @@ async def compute_crn_scores(
             logger.info("Zeroing CRN %s as a duplicate-IP node", node_id)
             total_score = Score(0)
 
-        decentralization_score = Score(
-            (1 - (measurements.nodes_with_identical_asn / measurements.total_nodes))
-            ** 2
-        )
+        if settings.DUPLICATE_IP_ENFORCED and measurements.duplicate_ip:
+            decentralization_score = Score(0)
+        else:
+            node_asn = asn_info.get(node_id, {}).get("asn")
+            identical = measurements.nodes_with_identical_asn
+            if node_asn is not None:
+                identical -= duplicate_asn_counts[node_asn]
+            decentralization_score = Score(
+                (1 - (identical / measurements.total_nodes)) ** 2
+            )
 
         # total_score = Score((performance_score * version_score) ** (1 / 2))
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -291,6 +291,7 @@ async def test_compute_crn_scores_zeroes_duplicate_when_enforced(monkeypatch, pe
     scores = await compute_crn_scores(period=period)
 
     assert scores[0].total_score == 0
+    assert scores[0].decentralization == 0  # zeroed alongside the score
     assert int(IssueCode.DUPLICATE_IP) in scores[0].codes
 
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -325,3 +325,80 @@ async def test_compute_crn_scores_keeps_duplicate_when_not_enforced(
     # Score is NOT zeroed, but the code is still published for early warning.
     assert scores[0].total_score == 0.95
     assert int(IssueCode.DUPLICATE_IP) in scores[0].codes
+
+
+@pytest.mark.asyncio
+async def test_compute_crn_scores_skips_dedup_when_node_fetch_fails(
+    monkeypatch, period
+):
+    monkeypatch.setattr(scoring.settings, "DUPLICATE_IP_ENFORCED", True)
+    rows = [
+        (
+            "crn-1",
+            CrnMeasurements(
+                total_nodes=2,
+                nodes_with_identical_asn=1,
+                record_count=5,
+                total_score=0.9,
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    async def boom():
+        raise RuntimeError("node API unreachable")
+
+    monkeypatch.setattr(scoring, "get_aleph_nodes", boom)
+
+    # Scoring still completes; duplicate detection is simply skipped.
+    scores = await compute_crn_scores(period=period)
+
+    assert len(scores) == 1
+    assert scores[0].total_score == 0.9
+    assert int(IssueCode.DUPLICATE_IP) not in scores[0].codes
+
+
+@pytest.mark.asyncio
+async def test_decentralization_excludes_duplicates_from_asn(monkeypatch, period):
+    # ASN 1234 has 4 nodes: 2 duplicates + 2 honest. The duplicates are
+    # subtracted from the honest node's identical count: (1 - (4 - 2) / 4) ** 2.
+    monkeypatch.setattr(scoring.settings, "DUPLICATE_IP_ENFORCED", True)
+    asn_entry = {"asn": 1234, "total_nodes": 4, "nodes_with_identical_asn": 4}
+    asn_info = {"honest1": asn_entry, "dup1": asn_entry, "dup2": asn_entry}
+    rows = [
+        (
+            "honest1",
+            CrnMeasurements(
+                total_nodes=4,
+                nodes_with_identical_asn=4,
+                record_count=5,
+                total_score=0.9,
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    async def fake_asn_info(_conn, period):
+        return asn_info
+
+    monkeypatch.setattr(scoring, "query_crn_asn_info", fake_asn_info)
+    monkeypatch.setattr(
+        scoring, "compute_duplicate_crns", lambda ip, t: {"dup1", "dup2"}
+    )
+
+    scores = await compute_crn_scores(period=period)
+
+    assert scores[0].node_id == "honest1"
+    assert scores[0].decentralization == 0.25  # (1 - (4 - 2) / 4) ** 2


### PR DESCRIPTION
When the duplicate-IP penalty fires, also force the node's decentralization to 0 and exclude it from the per-ASN identical count, so a Sybil cluster cannot inflate its ASN and drag down honest nodes' decentralization. total_nodes is left unchanged (a duplicate may be a fixable misconfiguration).

Guard the node-aggregate fetch in compute_crn_scores: on failure, log and skip duplicate detection for the run instead of aborting all CRN scoring.