### PR TITLE
Add CRN liveness status and dead-node score gate

### DIFF
--- a/aleph_scoring/config.py
+++ b/aleph_scoring/config.py
@@ -60,6 +60,13 @@ class Settings(BaseSettings):
     # one is scored; the rest are treated as duplicates and forced to 0.
     DUPLICATE_IP_ENFORCED: bool = True
 
+    # A CRN that has not proven it is a real CRN within DEAD_NODE_WINDOW is
+    # considered dead and forced to 0, so schedulers do not pick a host that is
+    # no longer running aleph-vm. Off by default; the status field is always
+    # published so consumers can act on it before enforcement is enabled.
+    DEAD_NODE_WINDOW: timedelta = timedelta(hours=24)
+    DEAD_NODE_ENFORCED: bool = False
+
     class Config:
         env_file = ".env"
         env_prefix = "ALEPH_SCORING_"

--- a/aleph_scoring/issue_codes.py
+++ b/aleph_scoring/issue_codes.py
@@ -21,6 +21,8 @@ class IssueCode(IntEnum):
     IPV4_UNSTABLE = 1003
     IPV6_UNSTABLE = 1004
     DUPLICATE_IP = 1005
+    NODE_DEAD = 1006
+    NODE_INACTIVE = 1007
 
     # 2xxx -- per-measurement failures (this measurement cycle)
     DNS_IPV4_FAIL = 2001
@@ -42,6 +44,10 @@ ISSUE_DESCRIPTIONS: Dict[IssueCode, str] = {
         "Shares an IPv4 or IPv6 /64 with an older CRN; only the "
         "earliest-registered node on a given address is scored."
     ),
+    IssueCode.NODE_DEAD: (
+        "No proof of being a real CRN for 24h; treated as dead and scored 0."
+    ),
+    IssueCode.NODE_INACTIVE: "The node is not currently proving it is a CRN.",
     IssueCode.DNS_IPV4_FAIL: "The node hostname did not resolve to an IPv4 address.",
     IssueCode.DNS_IPV6_FAIL: "The node hostname did not resolve to an IPv6 address.",
     IssueCode.IPV4_CHECK_FAILED: "The IPv4 reachability check (about/login) failed.",

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -100,6 +100,46 @@ async def query_crn_ip_stability(
     }
 
 
+async def query_crn_liveness(
+    conn: asyncpg.connection, period: Period
+) -> Dict[str, Dict]:
+    """Query per-CRN proof-of-liveness over the dead-node window.
+
+    Returns ``{node_id: {has_recent_proof, latest_proof}}`` for nodes measured
+    in the last DEAD_NODE_WINDOW.
+    """
+    sql = read_sql_file("query_crn_liveness.sql")
+
+    window_start = period.to_date - settings.DEAD_NODE_WINDOW
+    values = await conn.fetch(
+        sql,
+        settings.ALLOWED_METRICS_SENDER,
+        settings.ALEPH_POST_TYPE_METRICS,
+        window_start.replace(tzinfo=None),
+        period.to_date.replace(tzinfo=None),
+    )
+
+    return {
+        row["node_id"]: {
+            "has_recent_proof": row["has_recent_proof"],
+            "latest_proof": row["latest_proof"],
+        }
+        for row in values
+    }
+
+
+def crn_status(liveness: Optional[Dict]) -> str:
+    """Derive a CRN's liveness status from its proof history.
+
+    No proof in the dead-node window (or no entry at all) -> dead. Otherwise
+    active if the most recent measurement still proves CRN-ness, else inactive.
+    """
+    liveness = liveness or {}
+    if not liveness.get("has_recent_proof"):
+        return "dead"
+    return "active" if liveness.get("latest_proof") else "inactive"
+
+
 def crn_registration_times(node_data: Dict[str, Any]) -> Dict[str, float]:
     """Map each CRN node_id (hash) to its registration timestamp.
 
@@ -193,6 +233,10 @@ def crn_score_codes(measurements: CrnMeasurements) -> List[IssueCode]:
         codes.append(IssueCode.IPV6_UNSTABLE)
     if measurements.duplicate_ip:
         codes.append(IssueCode.DUPLICATE_IP)
+    if measurements.status == "dead":
+        codes.append(IssueCode.NODE_DEAD)
+    elif measurements.status == "inactive":
+        codes.append(IssueCode.NODE_INACTIVE)
     return codes
 
 
@@ -201,6 +245,7 @@ async def query_crn_measurements(
     asn_info: Dict,
     ip_stability: Dict,
     duplicate_ids: Set[str],
+    liveness: Dict,
     period: Period,
 ) -> AsyncIterable[tuple[str, CrnMeasurements]]:
     sql = read_sql_file("dev/neo/query_crn_scores.template.sql")
@@ -232,6 +277,7 @@ async def query_crn_measurements(
         row.update(node_asn_info)
         row.update(_ip_stability_fields(ip_stability.get(node_id)))
         row["duplicate_ip"] = node_id in duplicate_ids
+        row["status"] = crn_status(liveness.get(node_id))
         yield node_id, CrnMeasurements.parse_obj(row)
 
 
@@ -242,6 +288,7 @@ async def compute_crn_scores(
 
     asn_info: Dict[str, Dict] = await query_crn_asn_info(conn, period=period)
     ip_stability: Dict[str, Dict] = await query_crn_ip_stability(conn, period=period)
+    liveness: Dict[str, Dict] = await query_crn_liveness(conn, period=period)
 
     try:
         node_data = await get_aleph_nodes()
@@ -271,6 +318,7 @@ async def compute_crn_scores(
         asn_info,
         ip_stability,
         duplicate_ids,
+        liveness,
         period,
     ):
         # # This contains custom logic on the scores
@@ -362,7 +410,12 @@ async def compute_crn_scores(
             logger.info("Zeroing CRN %s as a duplicate-IP node", node_id)
             total_score = Score(0)
 
-        if settings.DUPLICATE_IP_ENFORCED and measurements.duplicate_ip:
+        is_dead = settings.DEAD_NODE_ENFORCED and measurements.status == "dead"
+        if is_dead:
+            logger.info("Zeroing CRN %s: dead (no proof of being a CRN)", node_id)
+            total_score = Score(0)
+
+        if is_dead or (settings.DUPLICATE_IP_ENFORCED and measurements.duplicate_ip):
             decentralization_score = Score(0)
         else:
             node_asn = asn_info.get(node_id, {}).get("asn")
@@ -381,6 +434,7 @@ async def compute_crn_scores(
                 total_score=total_score,
                 decentralization=decentralization_score,
                 measurements=measurements,
+                status=measurements.status,
                 codes=[int(c) for c in crn_score_codes(measurements)],
             )
         )

--- a/aleph_scoring/scoring/models.py
+++ b/aleph_scoring/scoring/models.py
@@ -2,9 +2,9 @@ from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConstrainedFloat, Field
 
-CrnStatus = Literal["active", "inactive", "dead"]
-
 from aleph_scoring.utils import Period
+
+CrnStatus = Literal["active", "inactive", "dead"]
 
 
 class Score(ConstrainedFloat):

--- a/aleph_scoring/scoring/models.py
+++ b/aleph_scoring/scoring/models.py
@@ -1,6 +1,8 @@
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, ConstrainedFloat, Field
+
+CrnStatus = Literal["active", "inactive", "dead"]
 
 from aleph_scoring.utils import Period
 
@@ -28,6 +30,9 @@ class CrnMeasurements(BaseNodeMeasurements):
     ip_penalized: bool = False
     # True when this node shares an IPv4 or IPv6 /64 with an older CRN.
     duplicate_ip: bool = False
+    # Liveness: active (proving CRN now), inactive (recently stopped), dead
+    # (no proof for the dead-node window).
+    status: CrnStatus = "active"
 
 
 class CcnMeasurements(BaseNodeMeasurements):
@@ -46,6 +51,7 @@ class CcnScore(AlephNodeScore):
 
 class CrnScore(AlephNodeScore):
     measurements: CrnMeasurements
+    status: CrnStatus = "active"
     codes: List[int] = Field(
         default_factory=list,
         description="Numeric diagnostic codes explaining the score (see IssueCode)",

--- a/aleph_scoring/scoring/sql/query_crn_liveness.sql
+++ b/aleph_scoring/scoring/sql/query_crn_liveness.sql
@@ -1,0 +1,43 @@
+-- Per-CRN liveness over a short window (DEAD_NODE_WINDOW).
+--
+-- `proof` is true when a measurement demonstrates the node is a real CRN:
+-- it answered the diagnostic VM (IPv6 ping or HTTP), served its own node_hash,
+-- or returned a valid aleph-vm version. Ping and node_hash are unspoofable; the
+-- diagnostic-VM HTTP and version signals are weakly spoofable.
+--
+-- $1 owner, $2 post type, $3 window start, $4 window end.
+WITH proofs AS (
+    SELECT
+        node ->> 'node_id' AS node_id,
+        date_trunc('hour', posts.creation_datetime) AS hour,
+        (
+            (node ->> 'diagnostic_vm_ping_latency') IS NOT NULL
+            OR (node ->> 'diagnostic_vm_latency') IS NOT NULL
+            OR COALESCE(
+                (node ->> 'config_node_hash') = (node ->> 'node_id'), false
+            )
+            OR is_version_valid(
+                'aleph-vm',
+                node ->> 'version',
+                to_timestamp((node ->> 'measured_at')::float)::date
+            ) = 1
+        ) AS proof
+    FROM posts,
+         jsonb_array_elements(content -> 'metrics' -> 'crn') node
+    WHERE owner = $1
+      AND type = $2
+      AND posts.creation_datetime >= $3::timestamp
+      AND posts.creation_datetime < $4::timestamp
+),
+per_hour AS (
+    SELECT node_id, hour, bool_or(proof) AS proof
+    FROM proofs
+    GROUP BY node_id, hour
+)
+SELECT
+    node_id,
+    COALESCE(bool_or(proof), false) AS has_recent_proof,
+    -- proof state of the most recent hour, used to split active vs inactive.
+    COALESCE((array_agg(proof ORDER BY hour DESC))[1], false) AS latest_proof
+FROM per_hour
+GROUP BY node_id;

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,193 @@
+# Scoring Rules & Decision Impact
+
+How node scores are computed, and every rule/condition that moves a score.
+
+## How scoring works
+
+Scoring is a stateless aggregation over the metrics that this tool publishes to
+the Aleph network (post type `aleph-network-metrics`). For each scoring run, the
+SQL queries read every metrics post in the window from the Aleph node's Postgres
+`posts` table and aggregate them per node. All scores are floats in `[0, 1]`.
+
+Two node types are scored independently: **CCN** (Core Channel Node) and **CRN**
+(Compute Resource Node). Each node gets a `total_score` (performance) and a
+separate `decentralization` value; both are published and combined downstream.
+
+## Configuration
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `SCORE_METRICS_PERIOD` | 730 days | Window of metrics aggregated into a score |
+| `MAX_METRICS_AGE` | 3 hours | If the newest metrics are older than this, the run aborts |
+| `VERSION_GRACE_PERIOD` | 14 days | A replaced software version still counts as valid for this long |
+| `IP_STABILITY_WINDOW` | 365 days | Window for the CRN IP-stability check |
+| `IP_MAX_CHANGES` | 2 | IPv4/IPv6-/64 changes at or above this penalize the node |
+| `IP_STABILITY_ENFORCED` | `false` | Whether the IP-stability penalty actually zeroes scores |
+| `DUPLICATE_IP_ENFORCED` | `true` | Whether the duplicate-IP penalty actually zeroes scores |
+| `DEAD_NODE_WINDOW` | 24 hours | Window in which a CRN must prove it is a real CRN |
+| `DEAD_NODE_ENFORCED` | `false` | Whether dead nodes are actually forced to 0 |
+
+All are overridable via `ALEPH_SCORING_<NAME>` env vars.
+
+## Run-level preconditions
+
+| Condition | Decision impact |
+|---|---|
+| Newest metrics older than `MAX_METRICS_AGE` | Entire scoring run aborts (exit code 2); no scores published |
+| A node has no ASN info in the window | Node is **skipped** — it receives no score this run |
+
+## CRN scoring
+
+### 1. Performance score (`total_score`)
+
+Computed in `sql/dev/neo/query_crn_scores.template.sql`. Per hour, the 67th
+percentile of each latency is taken; per hour a quality factor is built, weighted
+by recency, summed over the window, and raised to the power `0.75`.
+
+Per-hour quality factor:
+
+```
+( f(base_latency)        # GREATEST(1 - base_latency^2 / 4,  0)   IPv6 about/login
+* f(diagnostic_vm_latency)# GREATEST(1 - dvm_latency^2  / 4,  0)
+* f(full_check_latency) )^(1/3)  # GREATEST(1 - full_check^2 / 40, 0)
+* version_valid          # 0 or 1 (see below)
+```
+
+| Condition | Decision impact |
+|---|---|
+| Lower latencies | Higher quality factor → higher score |
+| Any latency high enough that `1 - latency^2/k <= 0` | That latency's factor is 0 → the hour contributes 0 |
+| `version_valid = 0` for an hour | That hour contributes 0 to the score |
+| More recent measurements | Weighted more (geometric decay over recency rank) |
+
+### 2. Version validity (`is_version_valid`)
+
+Per measurement, the reported `aleph-vm` version is checked against the
+`software_versions` table.
+
+| Condition | Result |
+|---|---|
+| Version current at measurement time | `version_valid = 1` |
+| Version replaced, but within `VERSION_GRACE_PERIOD` (14 days) | `version_valid = 1` |
+| Version unknown or replaced longer ago | `version_valid = 0` → contributes 0 to score |
+
+### 3. Decentralization (separate output)
+
+```
+decentralization = (1 - nodes_with_identical_asn / total_nodes) ^ 2
+```
+
+| Condition | Decision impact |
+|---|---|
+| Node alone in its ASN | `decentralization = 1` |
+| Node shares its ASN with others | Lower, approaching 0 as the share grows |
+| Every node in the same ASN | `decentralization = 0` |
+
+Reported alongside `total_score`; not folded into it here.
+
+### 4. IP-stability penalty
+
+Over `IP_STABILITY_WINDOW`, a representative IP per node per hour is taken
+(`mode()`), and address transitions are counted (`LAG`, nulls ignored). IPv6 is
+compared at the **/64 prefix** (host bits may rotate freely). Active only when
+`IP_STABILITY_ENFORCED = true`.
+
+| Condition (within window) | Decision impact | Issue code |
+|---|---|---|
+| No IPv4 observed | `total_score → 0` (when enforced) | 1001 `NO_IPV4` |
+| No IPv6 observed | `total_score → 0` (when enforced) | 1002 `NO_IPV6` |
+| IPv4 changed `>= IP_MAX_CHANGES` (2) times | `total_score → 0` (when enforced) | 1003 `IPV4_UNSTABLE` |
+| IPv6 /64 changed `>= IP_MAX_CHANGES` (2) times | `total_score → 0` (when enforced) | 1004 `IPV6_UNSTABLE` |
+| No recorded IP history yet (new node) | No penalty (defaults non-penalizing) | — |
+
+Scoring-reason codes are published whenever the condition holds, even while
+`IP_STABILITY_ENFORCED = false`, so operators get early warning before scores
+drop.
+
+### 5. Duplicate-IP penalty
+
+Each node's most-recent representative IPv4 and IPv6 /64 are grouped across all
+measured CRNs. For each address (IPv4 and /64 grouped independently), only the
+**earliest-registered** node (node aggregate `time`) keeps its score. Active
+only when `DUPLICATE_IP_ENFORCED = true`.
+
+| Condition | Decision impact | Issue code |
+|---|---|---|
+| Shares its IPv4 with an older CRN | `total_score → 0` (when enforced) | 1005 `DUPLICATE_IP` |
+| Shares its IPv6 /64 with an older CRN | `total_score → 0` (when enforced) | 1005 `DUPLICATE_IP` |
+| Earliest-registered node on the address | Kept — full score | — |
+| Unique address | No penalty | — |
+
+A node is penalized if it is not the earliest in its IPv4 cohort **or** its /64
+cohort. The code is published whenever the condition holds, even while
+enforcement is off. Caveat: NAT/reverse-proxy setups can legitimately share an
+IPv4 — observe the published codes before enabling enforcement.
+
+### 6. Liveness status (active / inactive / dead)
+
+Separately from the performance decay, each CRN gets a `status` (published
+top-level on the score) based on whether it recently **proved it is a real CRN**
+— answering the diagnostic VM (IPv6 ping or HTTP), serving its own `node_hash`,
+or returning a valid aleph-vm version. This stops the gradual decay from leaving
+a non-CRN (e.g. an IP re-assigned to a plain webserver) looking healthy to
+schedulers for ~a week.
+
+| Condition | Status | Decision impact | Issue code |
+|---|---|---|---|
+| Latest measurement proves CRN-ness | `active` | normal score | — |
+| Proved within `DEAD_NODE_WINDOW` but not latest | `inactive` | normal score | 1007 `NODE_INACTIVE` |
+| No proof for `DEAD_NODE_WINDOW` (24h) | `dead` | `total_score → 0`, `decentralization → 0` (when enforced) | 1006 `NODE_DEAD` |
+
+`status` is **always** published so schedulers/load-balancers can avoid dead
+nodes even before `DEAD_NODE_ENFORCED` is turned on. A node that keeps proving
+CRN-ness still gets the full performance-decay grace; only *no proof for 24h*
+triggers the hard 0. Ping and `node_hash` proofs are unspoofable; the
+diagnostic-VM HTTP and version proofs are weakly spoofable.
+
+## CCN scoring
+
+Same structure as CRN, with CCN-specific latencies and the `pyaleph` version.
+
+Per-hour quality factor:
+
+```
+( f(base_latency)            # 1 - base_latency^2 / 4
+* f(metrics_latency)         # 1 - metrics_latency^2 / 4
+* f(aggregate_latency)       # 1 - aggregate_latency^2 / 8
+* f(file_download_latency) )^(1/4)  # 1 - file_download_latency^2 / 8
+* version_valid
+```
+
+Decentralization is identical to CRN. The IP-stability penalty is **CRN-only**.
+
+## Issue codes
+
+Compact numeric codes published per node so operators can self-diagnose. Names
+live in `aleph_scoring/issue_codes.py` (the source of truth); only the integers
+appear in the JSON. **Values are a stability contract — never reused or
+renumbered.**
+
+### Scoring reasons (1xxx) — on `CrnScore.codes`
+
+| Code | Name | Meaning |
+|---|---|---|
+| 1001 | `NO_IPV4` | No IPv4 observed in the stability window |
+| 1002 | `NO_IPV6` | No IPv6 observed in the stability window |
+| 1003 | `IPV4_UNSTABLE` | IPv4 address changed too many times |
+| 1004 | `IPV6_UNSTABLE` | IPv6 /64 prefix changed too many times |
+| 1005 | `DUPLICATE_IP` | Shares an IPv4 or IPv6 /64 with an older CRN |
+| 1006 | `NODE_DEAD` | No proof of being a CRN for 24h; treated as dead |
+| 1007 | `NODE_INACTIVE` | Not currently proving it is a CRN |
+
+### Per-measurement (2xxx) — on `CrnMetrics.codes`
+
+| Code | Name | Meaning |
+|---|---|---|
+| 2001 | `DNS_IPV4_FAIL` | Hostname did not resolve to an IPv4 address |
+| 2002 | `DNS_IPV6_FAIL` | Hostname did not resolve to an IPv6 address |
+| 2003 | `IPV4_CHECK_FAILED` | IPv4 reachability check (about/login) failed |
+| 2004 | `IPV6_CHECK_FAILED` | IPv6 reachability check (about/login) failed |
+| 2005 | `VERSION_UNAVAILABLE` | aleph-vm version could not be read |
+| 2006 | `DIAG_VM_UNREACHABLE` | Diagnostic VM did not respond |
+| 2007 | `FULL_CHECK_FAILED` | status/check/fastapi probe failed |
+| 2999 | `UNKNOWN_MEASUREMENT_ERROR` | Unexpected error while measuring; see node logs |

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -9,6 +9,7 @@ from aleph_scoring.scoring import (
     compute_crn_scores,
     compute_duplicate_crns,
     crn_score_codes,
+    crn_status,
 )
 from aleph_scoring.scoring.models import CcnMeasurements, CrnMeasurements
 from aleph_scoring.utils import Period
@@ -56,8 +57,16 @@ def _patch_db(
         async def fake_nodes():
             return {"resource_nodes": []}
 
+        async def fake_liveness(_conn, period):
+            # Every node proves liveness, so status defaults to active in tests
+            # that don't care about it.
+            return {
+                nid: {"has_recent_proof": True, "latest_proof": True} for nid, _ in rows
+            }
+
         monkeypatch.setattr(scoring, stability_name, fake_stability)
         monkeypatch.setattr(scoring, "get_aleph_nodes", fake_nodes)
+        monkeypatch.setattr(scoring, "query_crn_liveness", fake_liveness)
 
 
 @pytest.mark.asyncio
@@ -421,3 +430,78 @@ async def test_decentralization_excludes_duplicates_from_asn(monkeypatch, period
 
     assert scores[0].node_id == "honest1"
     assert scores[0].decentralization == 0.25  # (1 - (4 - 2) / 4) ** 2
+
+
+@pytest.mark.parametrize(
+    "liveness, expected",
+    [
+        (None, "dead"),  # no entry -> never measured recently
+        ({"has_recent_proof": False, "latest_proof": False}, "dead"),
+        ({"has_recent_proof": True, "latest_proof": True}, "active"),
+        ({"has_recent_proof": True, "latest_proof": False}, "inactive"),
+    ],
+)
+def test_crn_status(liveness, expected):
+    assert crn_status(liveness) == expected
+
+
+@pytest.mark.asyncio
+async def test_compute_crn_scores_zeroes_dead_when_enforced(monkeypatch, period):
+    monkeypatch.setattr(scoring.settings, "DEAD_NODE_ENFORCED", True)
+    rows = [
+        (
+            "crn-dead",
+            CrnMeasurements(
+                total_nodes=2,
+                nodes_with_identical_asn=1,
+                record_count=5,
+                total_score=0.95,
+                status="dead",
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    scores = await compute_crn_scores(period=period)
+
+    assert scores[0].total_score == 0
+    assert scores[0].decentralization == 0
+    assert scores[0].status == "dead"
+    assert int(IssueCode.NODE_DEAD) in scores[0].codes
+
+
+@pytest.mark.asyncio
+async def test_compute_crn_scores_keeps_dead_when_not_enforced(monkeypatch, period):
+    monkeypatch.setattr(scoring.settings, "DEAD_NODE_ENFORCED", False)
+    rows = [
+        (
+            "crn-dead",
+            CrnMeasurements(
+                total_nodes=2,
+                nodes_with_identical_asn=1,
+                record_count=5,
+                total_score=0.95,
+                status="dead",
+            ),
+        ),
+    ]
+    _patch_db(
+        monkeypatch,
+        asn_info_name="query_crn_asn_info",
+        measurements_name="query_crn_measurements",
+        stability_name="query_crn_ip_stability",
+        rows=rows,
+    )
+
+    scores = await compute_crn_scores(period=period)
+
+    # Status and code are published for schedulers, but the score is untouched.
+    assert scores[0].total_score == 0.95
+    assert scores[0].status == "dead"
+    assert int(IssueCode.NODE_DEAD) in scores[0].codes

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -189,6 +189,8 @@ def _crn_measurements(**overrides) -> CrnMeasurements:
             [IssueCode.NO_IPV6, IssueCode.IPV4_UNSTABLE],
         ),
         ({"duplicate_ip": True}, [IssueCode.DUPLICATE_IP]),
+        ({"status": "dead"}, [IssueCode.NODE_DEAD]),
+        ({"status": "inactive"}, [IssueCode.NODE_INACTIVE]),
     ],
 )
 def test_crn_score_codes(overrides, expected):


### PR DESCRIPTION
Publish a per-CRN status (active/inactive/dead) based on recent proof of being a real CRN (diagnostic VM, node_hash, or valid version) over a 24h window. Dead nodes (no proof for 24h) are forced to 0 when DEAD_NODE_ENFORCED is on; the status is always published so schedulers can avoid them regardless. Independent of the performance-decay grace.