### PR TITLE
Use VM IPv6 pool for CRN IP stability and duplicate detection

### DIFF
--- a/aleph_scoring/metrics/__init__.py
+++ b/aleph_scoring/metrics/__init__.py
@@ -388,13 +388,27 @@ async def get_ccn_metrics(
     )
 
 
-async def fetch_node_hash(
-    session: aiohttp.ClientSession, node_url: str, timeout_seconds: int
-) -> Optional[str]:
-    """Fetch the node_hash the node reports at /status/config.
+@dataclass
+class NodeConfig:
+    """Subset of a node's /status/config we record for scoring."""
 
-    Used to verify a node really serves its own identity: a node that points
-    its domain at someone else's server returns that server's node_hash.
+    node_hash: Optional[str] = None
+    ipv6_pool: Optional[str] = None
+
+
+async def fetch_node_config(
+    session: aiohttp.ClientSession, node_url: str, timeout_seconds: int
+) -> NodeConfig:
+    """Fetch the node_hash and VM IPv6 pool the node reports at /status/config.
+
+    ``node_hash`` verifies a node really serves its own identity: a node that
+    points its domain at someone else's server returns that server's node_hash.
+
+    ``ipv6_pool`` is ``networking.IPV6_ADDRESS_POOL`` — the range the node
+    allocates VM addresses from. It is distinct from the node's own access
+    IPv6 (the AAAA record): some operators give the node a default IPv6 for
+    access and route a separate range for VMs, so the pool is the address that
+    matters for IPv6 stability and duplicate detection.
     """
     url = f"{node_url}status/config"
     try:
@@ -402,7 +416,11 @@ async def fetch_node_hash(
             async with session.get(url) as resp:
                 resp.raise_for_status()
                 config = await resp.json()
-                return config.get("node_hash")
+                networking = config.get("networking") or {}
+                return NodeConfig(
+                    node_hash=config.get("node_hash"),
+                    ipv6_pool=networking.get("IPV6_ADDRESS_POOL"),
+                )
     except (
         aiohttp.ClientResponseError,
         aiohttp.ClientConnectorError,
@@ -413,7 +431,7 @@ async def fetch_node_hash(
         asyncio.TimeoutError,
     ) as e:
         logger.debug("Error fetching config from %s: %s: %s", url, type(e).__name__, e)
-        return None
+        return NodeConfig()
 
 
 async def fetch_supported_features(
@@ -572,7 +590,7 @@ async def _measure_crn_metrics(
             sessions.ipv4, f"{url}about/login", expected_status=401
         )
     )[0]
-    config_node_hash = await fetch_node_hash(sessions.any_ip, url, timeout_seconds=5)
+    node_config = await fetch_node_config(sessions.any_ip, url, timeout_seconds=5)
 
     measured_at = datetime.now(tz=timezone.utc)
 
@@ -601,7 +619,8 @@ async def _measure_crn_metrics(
         features=features_supported or [],
         ipv4=ipv4,
         ipv6=ipv6,
-        config_node_hash=config_node_hash,
+        ipv6_pool=node_config.ipv6_pool,
+        config_node_hash=node_config.node_hash,
         codes=[int(c) for c in codes],
     )
 

--- a/aleph_scoring/metrics/models.py
+++ b/aleph_scoring/metrics/models.py
@@ -35,7 +35,13 @@ class CrnMetrics(AlephNodeMetrics):
         default=None, description="Resolved IPv4 address, used to detect IP changes"
     )
     ipv6: Optional[str] = Field(
-        default=None, description="Resolved IPv6 address, used to detect IP changes"
+        default=None, description="Resolved IPv6 address (the node's own access IPv6)"
+    )
+    ipv6_pool: Optional[str] = Field(
+        default=None,
+        description="networking.IPV6_ADDRESS_POOL from /status/config: the range "
+        "the node allocates VM IPv6 addresses from. Used for IPv6 stability and "
+        "duplicate detection, since it can differ from the node's access IPv6",
     )
     config_node_hash: Optional[str] = Field(
         default=None,

--- a/aleph_scoring/scoring/__init__.py
+++ b/aleph_scoring/scoring/__init__.py
@@ -93,7 +93,7 @@ async def query_crn_ip_stability(
             "ipv4_changes": row["ipv4_changes"],
             "ipv6_changes": row["ipv6_changes"],
             "ipv4": row["current_ipv4"],
-            "ipv6_prefix": row["current_ipv6_prefix"],
+            "ipv6_pool": row["current_ipv6_pool"],
             "verified": row["verified"],
         }
         for row in values
@@ -160,9 +160,9 @@ def compute_duplicate_crns(
     ip_stability: Dict[str, Dict],
     registration_times: Dict[str, float],
 ) -> Set[str]:
-    """Return node_ids that share an IPv4 or IPv6 /64 with another CRN.
+    """Return node_ids that share an IPv4 or IPv6 VM pool with another CRN.
 
-    For each address (IPv4 and IPv6 /64 grouped independently) one node keeps
+    For each address (IPv4 and IPv6 pool grouped independently) one node keeps
     its score and the rest are flagged. The keeper is the node that proved its
     identity at /status/config (``verified``) — this defeats DNS spoofing, since
     a node pointing its domain at someone else's server returns the wrong hash
@@ -171,7 +171,7 @@ def compute_duplicate_crns(
     and unknown registration times are broken by node_id for determinism.
     """
     penalized: Set[str] = set()
-    for key in ("ipv4", "ipv6_prefix"):
+    for key in ("ipv4", "ipv6_pool"):
         groups: Dict[str, List[str]] = {}
         for node_id, info in ip_stability.items():
             address = info.get(key)

--- a/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
+++ b/aleph_scoring/scoring/sql/query_crn_ip_stability.sql
@@ -4,9 +4,12 @@
 -- noise, then LAG counts real address transitions (nulls ignored, so transient
 -- resolution failures do not count as a change).
 --
--- IPv6 is compared at the /64 prefix only: CRNs are assigned a routed /64, so
--- the host bits may legitimately rotate (privacy / per-VM addresses) without
--- the node having moved. Only a /64 change is a real relocation.
+-- IPv6 stability tracks the node's VM IPv6 pool (networking.IPV6_ADDRESS_POOL
+-- from /status/config), not the node's own access IPv6 (the AAAA record). Some
+-- operators give the node a default IPv6 for access and route a separate range
+-- for VMs, so the pool is the address that actually identifies the node. The
+-- pool is normalised to its network/prefix so non-canonical host bits do not
+-- count as a change.
 --
 -- $1 owner, $2 post type, $3 window start, $4 window end.
 WITH ip_observations AS (
@@ -15,10 +18,10 @@ WITH ip_observations AS (
         date_trunc('hour', posts.creation_datetime) AS hour,
         node ->> 'ipv4' AS ipv4,
         CASE
-            WHEN node ->> 'ipv6' IS NOT NULL AND node ->> 'ipv6' <> ''
-            THEN network(set_masklen((node ->> 'ipv6')::inet, 64))::text
+            WHEN node ->> 'ipv6_pool' IS NOT NULL AND node ->> 'ipv6_pool' <> ''
+            THEN network((node ->> 'ipv6_pool')::inet)::text
             ELSE NULL
-        END AS ipv6_prefix,
+        END AS ipv6_pool,
         -- The node served its own registered hash at /status/config.
         ((node ->> 'config_node_hash') = (node ->> 'node_id')) AS verified
     FROM posts,
@@ -33,7 +36,7 @@ per_hour AS (
         node_id,
         hour,
         mode() WITHIN GROUP (ORDER BY ipv4) AS ipv4,
-        mode() WITHIN GROUP (ORDER BY ipv6_prefix) AS ipv6_prefix,
+        mode() WITHIN GROUP (ORDER BY ipv6_pool) AS ipv6_pool,
         bool_or(verified) AS verified
     FROM ip_observations
     GROUP BY node_id, hour
@@ -43,29 +46,29 @@ ordered AS (
         node_id,
         hour,
         ipv4,
-        ipv6_prefix,
+        ipv6_pool,
         verified,
         LAG(ipv4) OVER (PARTITION BY node_id ORDER BY hour) AS prev_ipv4,
-        LAG(ipv6_prefix) OVER (PARTITION BY node_id ORDER BY hour) AS prev_ipv6_prefix
+        LAG(ipv6_pool) OVER (PARTITION BY node_id ORDER BY hour) AS prev_ipv6_pool
     FROM per_hour
 )
 SELECT
     node_id,
     bool_or(ipv4 IS NOT NULL) AS has_ipv4,
-    bool_or(ipv6_prefix IS NOT NULL) AS has_ipv6,
+    bool_or(ipv6_pool IS NOT NULL) AS has_ipv6,
     count(*) FILTER (
         WHERE prev_ipv4 IS NOT NULL AND ipv4 IS NOT NULL AND ipv4 <> prev_ipv4
     ) AS ipv4_changes,
     count(*) FILTER (
-        WHERE prev_ipv6_prefix IS NOT NULL
-          AND ipv6_prefix IS NOT NULL
-          AND ipv6_prefix <> prev_ipv6_prefix
+        WHERE prev_ipv6_pool IS NOT NULL
+          AND ipv6_pool IS NOT NULL
+          AND ipv6_pool <> prev_ipv6_pool
     ) AS ipv6_changes,
     -- Most-recent non-null address, used to group duplicate CRNs.
     (array_agg(ipv4 ORDER BY hour DESC) FILTER (WHERE ipv4 IS NOT NULL))[1]
         AS current_ipv4,
-    (array_agg(ipv6_prefix ORDER BY hour DESC) FILTER (WHERE ipv6_prefix IS NOT NULL))[1]
-        AS current_ipv6_prefix,
+    (array_agg(ipv6_pool ORDER BY hour DESC) FILTER (WHERE ipv6_pool IS NOT NULL))[1]
+        AS current_ipv6_pool,
     -- True if the node ever served its own hash in the window.
     coalesce(bool_or(verified), false) AS verified
 FROM ordered

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -21,7 +21,7 @@ separate `decentralization` value; both are published and combined downstream.
 | `MAX_METRICS_AGE` | 3 hours | If the newest metrics are older than this, the run aborts |
 | `VERSION_GRACE_PERIOD` | 14 days | A replaced software version still counts as valid for this long |
 | `IP_STABILITY_WINDOW` | 365 days | Window for the CRN IP-stability check |
-| `IP_MAX_CHANGES` | 2 | IPv4/IPv6-/64 changes at or above this penalize the node |
+| `IP_MAX_CHANGES` | 2 | IPv4/IPv6-pool changes at or above this penalize the node |
 | `IP_STABILITY_ENFORCED` | `false` | Whether the IP-stability penalty actually zeroes scores |
 | `DUPLICATE_IP_ENFORCED` | `true` | Whether the duplicate-IP penalty actually zeroes scores |
 | `DEAD_NODE_WINDOW` | 24 hours | Window in which a CRN must prove it is a real CRN |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -88,16 +88,20 @@ Reported alongside `total_score`; not folded into it here.
 ### 4. IP-stability penalty
 
 Over `IP_STABILITY_WINDOW`, a representative IP per node per hour is taken
-(`mode()`), and address transitions are counted (`LAG`, nulls ignored). IPv6 is
-compared at the **/64 prefix** (host bits may rotate freely). Active only when
+(`mode()`), and address transitions are counted (`LAG`, nulls ignored). For
+IPv6 the node's **VM address pool** (`networking.IPV6_ADDRESS_POOL` from
+`/status/config`) is used, not the node's own access IPv6 (the AAAA record):
+some operators give the node a default IPv6 for access and route a separate
+range for VMs, so the pool is what identifies the node. The pool is normalised
+to its network/prefix before comparison. Active only when
 `IP_STABILITY_ENFORCED = true`.
 
 | Condition (within window) | Decision impact | Issue code |
 |---|---|---|
 | No IPv4 observed | `total_score → 0` (when enforced) | 1001 `NO_IPV4` |
-| No IPv6 observed | `total_score → 0` (when enforced) | 1002 `NO_IPV6` |
+| No IPv6 pool observed | `total_score → 0` (when enforced) | 1002 `NO_IPV6` |
 | IPv4 changed `>= IP_MAX_CHANGES` (2) times | `total_score → 0` (when enforced) | 1003 `IPV4_UNSTABLE` |
-| IPv6 /64 changed `>= IP_MAX_CHANGES` (2) times | `total_score → 0` (when enforced) | 1004 `IPV6_UNSTABLE` |
+| IPv6 pool changed `>= IP_MAX_CHANGES` (2) times | `total_score → 0` (when enforced) | 1004 `IPV6_UNSTABLE` |
 | No recorded IP history yet (new node) | No penalty (defaults non-penalizing) | — |
 
 Scoring-reason codes are published whenever the condition holds, even while
@@ -106,20 +110,20 @@ drop.
 
 ### 5. Duplicate-IP penalty
 
-Each node's most-recent representative IPv4 and IPv6 /64 are grouped across all
-measured CRNs. For each address (IPv4 and /64 grouped independently), only the
-**earliest-registered** node (node aggregate `time`) keeps its score. Active
-only when `DUPLICATE_IP_ENFORCED = true`.
+Each node's most-recent representative IPv4 and IPv6 VM pool are grouped across
+all measured CRNs. For each address (IPv4 and IPv6 pool grouped independently),
+only the **earliest-registered** node (node aggregate `time`) keeps its score.
+Active only when `DUPLICATE_IP_ENFORCED = true`.
 
 | Condition | Decision impact | Issue code |
 |---|---|---|
 | Shares its IPv4 with an older CRN | `total_score → 0` (when enforced) | 1005 `DUPLICATE_IP` |
-| Shares its IPv6 /64 with an older CRN | `total_score → 0` (when enforced) | 1005 `DUPLICATE_IP` |
+| Shares its IPv6 pool with an older CRN | `total_score → 0` (when enforced) | 1005 `DUPLICATE_IP` |
 | Earliest-registered node on the address | Kept — full score | — |
 | Unique address | No penalty | — |
 
-A node is penalized if it is not the earliest in its IPv4 cohort **or** its /64
-cohort. The code is published whenever the condition holds, even while
+A node is penalized if it is not the earliest in its IPv4 cohort **or** its
+IPv6-pool cohort. The code is published whenever the condition holds, even while
 enforcement is off. Caveat: NAT/reverse-proxy setups can legitimately share an
 IPv4 — observe the published codes before enabling enforcement.
 
@@ -174,8 +178,8 @@ renumbered.**
 | 1001 | `NO_IPV4` | No IPv4 observed in the stability window |
 | 1002 | `NO_IPV6` | No IPv6 observed in the stability window |
 | 1003 | `IPV4_UNSTABLE` | IPv4 address changed too many times |
-| 1004 | `IPV6_UNSTABLE` | IPv6 /64 prefix changed too many times |
-| 1005 | `DUPLICATE_IP` | Shares an IPv4 or IPv6 /64 with an older CRN |
+| 1004 | `IPV6_UNSTABLE` | IPv6 VM pool changed too many times |
+| 1005 | `DUPLICATE_IP` | Shares an IPv4 or IPv6 VM pool with an older CRN |
 | 1006 | `NODE_DEAD` | No proof of being a CRN for 24h; treated as dead |
 | 1007 | `NODE_INACTIVE` | Not currently proving it is a CRN |
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,15 @@
+import aiohttp
 import pytest
 from urllib3.util import parse_url
 
 from aleph_scoring import metrics
 from aleph_scoring.issue_codes import IssueCode
-from aleph_scoring.metrics import NodeInfo, crn_measurement_codes, get_crn_metrics
+from aleph_scoring.metrics import (
+    NodeInfo,
+    crn_measurement_codes,
+    fetch_node_config,
+    get_crn_metrics,
+)
 
 
 def _kwargs(**overrides):
@@ -72,3 +78,65 @@ async def test_get_crn_metrics_reports_unexpected_error(monkeypatch):
     assert result.url == "https://crn.example/"
     assert result.codes == [int(IssueCode.UNKNOWN_MEASUREMENT_ERROR)]
     assert result.base_latency is None
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Session whose get() yields a fixed payload, or raises on request."""
+
+    def __init__(self, payload=None, error=None):
+        self._payload = payload
+        self._error = error
+
+    def get(self, url):
+        if self._error is not None:
+            raise self._error
+        return _FakeResponse(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_fetch_node_config_extracts_hash_and_pool():
+    session = _FakeSession(
+        {
+            "node_hash": "b" * 64,
+            "networking": {"IPV6_ADDRESS_POOL": "2607:5300:203:8300::/56"},
+        }
+    )
+    config = await fetch_node_config(session, "https://crn.example/", timeout_seconds=5)
+
+    assert config.node_hash == "b" * 64
+    assert config.ipv6_pool == "2607:5300:203:8300::/56"
+
+
+@pytest.mark.asyncio
+async def test_fetch_node_config_missing_networking_block():
+    session = _FakeSession({"node_hash": "c" * 64})
+    config = await fetch_node_config(session, "https://crn.example/", timeout_seconds=5)
+
+    assert config.node_hash == "c" * 64
+    assert config.ipv6_pool is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_node_config_on_error_returns_empty():
+    session = _FakeSession(error=aiohttp.ClientOSError("down"))
+    config = await fetch_node_config(session, "https://crn.example/", timeout_seconds=5)
+
+    assert config.node_hash is None
+    assert config.ipv6_pool is None

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -212,25 +212,25 @@ def test_crn_score_codes(overrides, expected):
             {"a": 1, "b": 2},
             {"b"},
         ),
-        # Same /64: earliest kept
+        # Same IPv6 pool: earliest kept
         (
-            {"a": {"ipv6_prefix": "2a01::/64"}, "b": {"ipv6_prefix": "2a01::/64"}},
+            {"a": {"ipv6_pool": "2a01::/64"}, "b": {"ipv6_pool": "2a01::/64"}},
             {"a": 5, "b": 3},
             {"a"},
         ),
-        # Shares IPv4 with one and /64 with another -> only earliest survives
+        # Shares IPv4 with one and IPv6 pool with another -> only earliest survives
         (
             {
-                "a": {"ipv4": "1.1.1.1", "ipv6_prefix": "2a01::/64"},
+                "a": {"ipv4": "1.1.1.1", "ipv6_pool": "2a01::/64"},
                 "b": {"ipv4": "1.1.1.1"},
-                "c": {"ipv6_prefix": "2a01::/64"},
+                "c": {"ipv6_pool": "2a01::/64"},
             },
             {"a": 1, "b": 2, "c": 3},
             {"b", "c"},
         ),
         # Null addresses are not grouped
         (
-            {"a": {"ipv4": None, "ipv6_prefix": None}, "b": {"ipv4": None}},
+            {"a": {"ipv4": None, "ipv6_pool": None}, "b": {"ipv4": None}},
             {"a": 1, "b": 2},
             set(),
         ),


### PR DESCRIPTION
IPv6 stability and duplicate grouping now key off the node's VM address pool (networking.IPV6_ADDRESS_POOL from /status/config) instead of the AAAA record. Some operators give the node a default IPv6 for access and route a separate range for VMs, so the AAAA is the node's access address, not what identifies it.

- metrics: replace fetch_node_hash with fetch_node_config, which reads node_hash and ipv6_pool from a single /status/config fetch; add ipv6_pool to CrnMetrics.
- scoring: query_crn_ip_stability.sql sources IPv6 from ipv6_pool, normalised to its network/prefix; rename the ipv6_prefix columns and the dedup key to ipv6_pool.
- tests: cover fetch_node_config parsing and the failure path; update the duplicate-detection cases.
- docs: describe the pool-based IPv6 rule in rules.md.